### PR TITLE
Add support for Python 3

### DIFF
--- a/setup.command
+++ b/setup.command
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 try:
-    import StringIO
+    from StringIO import StringIO as sbIO
 except ImportError:
-    import io as StringIO
+    from io import BytesIO as sbIO
 import struct
 import os
 import sys
 import json
 
-PATH = os.path.dirname(sys.argv[0]) + '/'
+PATH = os.getcwd() + '/'
 RELATIVE_PATH = 'photos'
 PHOTO_PATH = PATH + RELATIVE_PATH
 
@@ -84,15 +84,15 @@ def getImageInfo(data):
     # See PNG 2. Edition spec (http://www.w3.org/TR/PNG/)
     # Bytes 0-7 are below, 4-byte chunk length, then 'IHDR'
     # and finally the 4-byte width, height
-    if ((size >= 24) and data.startswith('\211PNG\r\n\032\n') and
-          (data[12:16] == 'IHDR')):
+    if ((size >= 24) and data.startswith(b'\211PNG\r\n\032\n') and
+          (data[12:16] == b'IHDR')):
         content_type = 'image/png'
         w, h = struct.unpack(">LL", data[16:24])
         width = int(w)
         height = int(h)
 
     # Maybe this is for an older PNG version.
-    elif (size >= 16) and data.startswith('\211PNG\r\n\032\n'):
+    elif (size >= 16) and data.startswith(b'\211PNG\r\n\032\n'):
         # Check to see if we have the right content type
         content_type = 'image/png'
         w, h = struct.unpack(">LL", data[8:16])
@@ -100,9 +100,14 @@ def getImageInfo(data):
         height = int(h)
 
     # handle JPEGs
-    elif (size >= 2) and data.startswith('\377\330'):
+    elif (size >= 2) and data.startswith(b'\xff\xd8'):
         content_type = 'image/jpeg'
-        jpeg = StringIO.StringIO(data)
+        
+        try:
+            jpeg = sbIO(data) # Python 3
+        except:
+            jpeg = sbIO(str(data)) # Python 2
+        
         jpeg.read(2)
         b = jpeg.read(1)
         try:

--- a/setup.command
+++ b/setup.command
@@ -75,7 +75,6 @@ https://github.com/andyzg/gallery/issues/1''')
 # Thanks StackOverflow: http://stackoverflow.com/a/3175473 #
 ############################################################
 def getImageInfo(data):
-    data = str(data)
     size = len(data)
     height = -1
     width = -1

--- a/setup.command
+++ b/setup.command
@@ -81,18 +81,10 @@ def getImageInfo(data):
     width = -1
     content_type = ''
 
-    # handle GIFs
-    if (size >= 10) and data[:6] in ('GIF87a', 'GIF89a'):
-        # Check to see if content_type is correct
-        content_type = 'image/gif'
-        w, h = struct.unpack("<HH", data[6:10])
-        width = int(w)
-        height = int(h)
-
     # See PNG 2. Edition spec (http://www.w3.org/TR/PNG/)
     # Bytes 0-7 are below, 4-byte chunk length, then 'IHDR'
     # and finally the 4-byte width, height
-    elif ((size >= 24) and data.startswith('\211PNG\r\n\032\n') and
+    if ((size >= 24) and data.startswith('\211PNG\r\n\032\n') and
           (data[12:16] == 'IHDR')):
         content_type = 'image/png'
         w, h = struct.unpack(">LL", data[16:24])

--- a/setup.command
+++ b/setup.command
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-import StringIO
+try:
+    import StringIO
+except ImportError:
+    import io as StringIO
 import struct
 import os
 import sys
@@ -29,7 +32,7 @@ def get_images(path):
     result = []
     for img in filtered_items:
         width, height = 0, 0
-        with open(PHOTO_PATH + '/' + path + '/' + img) as f:
+        with open(PHOTO_PATH + '/' + path + '/' + img, 'rb') as f:
             _, width, height = getImageInfo(f.read())
         result.append({
             'width': width,


### PR DESCRIPTION
In Python 3, byte strings are more strict and must be prefixed with a `b`. So finding the image size needed a few changes, most of which is basically forcing all comparisons to be byte strings. Also Python 3 uses `ByteIO` rather than `StringIO`, so changes were made to make the two version compatible.

`open()` will now open each file as a binary, I think it was defaulting to opening it as a text file so I was getting encoding errors.

These changes fixed all the errors I was getting, but thanks for the awesome tool! (Will share gallery soon when I upload pics)